### PR TITLE
fix: Disable autobins so that only the gh-governor bin is installed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "gh-governor"
 version = "0.1.0"
 edition = "2024"
+autobins = false
+
+[[bin]]
+name = "gh-governor"
+path = "src/main.rs"
 
 [dependencies]
 base64 = "0.22.1"


### PR DESCRIPTION
Only the `gh-governor` should be installed with `cargo install`, the `e2e` one should not, this fixes that.